### PR TITLE
Added git env vars and config to bamboo script.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ RUN useradd --create-home --home-dir $HOME bamboo \
 
 USER bamboo
 
+ENV GIT_USER="APIC User"
+ENV GIT_EMAIL="apic.user@example.com"
+
 # Preparing agent environment
 WORKDIR /home/bamboo
 

--- a/bamboo-agent.sh
+++ b/bamboo-agent.sh
@@ -2,6 +2,10 @@
 
 cd /home/bamboo 
 
+# Git settings.
+git congig --global user.name $GIT_USER
+git config --global user.email $GIT_EMAIL
+
 if [ -z "${BAMBOO_SERVER}" ]; then
 	echo "Bamboo server URL undefined!" >&2
 	echo "Please set BAMBOO_SERVER environment variable to URL of your Bamboo instance." >&2


### PR DESCRIPTION
Added the following env vars:
`GIT_USER` and `GIT_EMAIL`

Also added git global config commands to bamboo script to set the user and email.  The default values can be overridden by setting `-e GIT_USER="username"` and `-e GIT_EMAIL="user ermail"`.